### PR TITLE
add component for easier routing

### DIFF
--- a/app/Http/Helpers.php
+++ b/app/Http/Helpers.php
@@ -1,0 +1,7 @@
+<?php
+
+if (!function_exists("array_except")) {
+    function array_except($array, $keys) {
+        return array_diff_key($array, array_flip((array) $keys));
+    }
+}

--- a/app/View/Components/Route.php
+++ b/app/View/Components/Route.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\View\Components;
+
+use Illuminate\View\Component;
+
+class Route extends Component
+{
+
+    public $name;
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     *
+     * @return \Illuminate\Contracts\View\View|\Closure|string
+     */
+    public function render()
+    {
+        return view('components.route');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/Http/Helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/resources/views/components/route.blade.php
+++ b/resources/views/components/route.blade.php
@@ -1,0 +1,22 @@
+@php
+
+$allowed = [
+    "class",
+    "style",
+    "id",
+];
+
+$used = array_merge(
+    [
+        "href"
+    ],
+    $allowed
+);
+@endphp
+
+
+<a href="{{
+    route($attributes->get("href"), $attributes->except($used))
+    }}" {{ $attributes->only($allowed) }}>
+    {{ $slot }}
+</a>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -21,6 +21,7 @@
         </style>
     </head>
     <body class="antialiased">
+    <x-route href="dashboard" uid="asdf" class="text-gray-600">dashboard</x-route>
         <div class="relative flex items-top justify-center min-h-screen bg-gray-100 dark:bg-gray-900 sm:items-center py-4 sm:pt-0">
             @if (Route::has('login'))
                 <div class="hidden fixed top-0 right-0 px-6 py-4 sm:block">


### PR DESCRIPTION
routing requires clunky blade syntax with string concat
or function calls to `route` which accepts a dictionary.

This component automatically passes attributes to the
route function while ignoring and merging common attributes
with the `a` tag such as `class, style, id`